### PR TITLE
Small fix

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -190,7 +190,9 @@ ry::build() {
 # assert_installed <name>
 # abort unless the given ruby is installed
 assert_installed() {
-  if [[ ! -d "$RY_LIB/rubies/$1" ]]; then
+  if [ -z "$1" ]; then
+    abort "ruby version missing"
+  elif [[ ! -d "$RY_LIB/rubies/$1" ]]; then
     abort "no such ruby: $1"
   fi
 }


### PR DESCRIPTION
Commands like `ry use` would not fail if no ruby version was given
