### PR TITLE
Don't setup bash completion in non-bash shells

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -81,8 +81,8 @@ ry::current() {
 #
 ry::setup() {
 cat <<sh
-export PATH="$(ry fullpath "$@")"
-. "$RY_PREFIX/lib/ry.bash_completion"
+export PATH="$(ry fullpath "$@")";
+if [ -n "\$BASH_VERSION" ]; then . "$RY_PREFIX/lib/ry.bash_completion"; fi
 sh
 }
 


### PR DESCRIPTION
I wish we could detect the shell before evaluation but there is no easy
way (esp. /proc is not available in OSX)
