### PR TITLE
Fix configure for custom ruby versions

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -169,7 +169,7 @@ ry::build() {
 
   if [[ -x "./configure" ]]; then
     log "running ./configure --prefix=\"$install_prefix\"..."
-    ./configure --prefix="$install_prefix" "$@"
+    ./configure --prefix="$install_prefix" "${@:2}"
   else
     log "no ./configure script found, skipping..."
   fi


### PR DESCRIPTION
It was passing the local name on to `configure` which was causing an error. It should exclude `$1` when running configure. There might be a better way to handle this, but this made it work for me.
