### PR TITLE
add zsh completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,4 @@ install:
 	install -d $(PREFIX)/bin $(PREFIX)/lib
 	install -C -m 0755 ./bin/ry $(PREFIX)/bin/ry
 	install -C -m 0644 ./lib/ry.bash_completion $(PREFIX)/lib/ry.bash_completion
+	install -C -m 0644 ./lib/ry.zsh_completion $(PREFIX)/lib/ry.zsh_completion

--- a/bin/ry
+++ b/bin/ry
@@ -83,6 +83,7 @@ ry::setup() {
 cat <<sh
 export PATH="$(ry fullpath "$@")";
 if [ -n "\$BASH_VERSION" ]; then . "$RY_PREFIX/lib/ry.bash_completion"; fi
+if [ -n "\$ZSH_VERSION" ]; then . "$RY_PREFIX/lib/ry.zsh_completion"; fi
 sh
 }
 

--- a/lib/ry.zsh_completion
+++ b/lib/ry.zsh_completion
@@ -1,0 +1,46 @@
+_ry() {
+  local -a rubies
+  if (( CURRENT > 2 )); then
+    shift words
+    (( CURRENT-- ))
+    subcmd="$words[1]"
+
+    case $subcmd in
+      setup|use|remove|rm|exec|binpath|fullpath)
+        rubies=($(_call_program rubies ry ls))
+      ;;
+      install)
+        if (( $+commands[ruby-build] )); then
+          rubies=($(_call_program rubies ruby-build --definitions))
+        fi
+      ;;
+      *)
+        rubies=()
+      ;;
+    esac
+    _describe rubies rubies
+  else
+    local -a commands
+    # usage is not listed so "use" completes directly
+    commands=(
+      version:'show ry version'
+      help:'show the help'
+      current:'show the current ruby name'
+      setup:'setup ry (with an optional ruby as an argument)'
+      ls:'output the installed rubies'
+      rubies:'output the installed rubies, and highlight the current one'
+      use:'use the given ruby'
+      install:'install the given ruby-build recipe'
+      remove:'remove the given rubies'
+      rm:'remove the given rubies'
+      exec:'execute a command in the context of each comma-separated ruby'
+      binpath:'print the bin directory for the given ruby'
+      fullpath:'print a modified version of $PATH that exclusively includes the given ruby'
+    )
+    rubies=($(_call_program rubies ry ls))
+    _describe commands commands
+    _describe rubies rubies
+  fi
+}
+
+compdef _ry ry


### PR DESCRIPTION
Hello,

This my try to implement zsh completion for ry.
It's the first time I write a zsh completion script, but it works well and seems clean.
- It's probably worth mentioning in the README that `ry setup` should be called in `.zshrc`, after compinit.
- Another solution, more idiomatic for zsh, is to let the user create a symlink in his `$fpath` and make the completion an autoloadable function.

I still need to make my mind about that.

See #9

P.S.: Just installed ry yesterday and very happy since. (I just did not expect `ry setup` with an argument to disallow `ry use` afterwards)
