### PR TITLE
ry exec: default to all installed rubies when none is given

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -258,10 +258,15 @@ ry::fullpath() {
 #
 # ry exec <name>[,<name2>[,...]] <command...>
 # execute the given command in the context of the given rub{y,ies}
+# use all installed rubies if <name> is "all"
 #
 ry::exec() {
   local names="$1"; shift
-  names="$(tr , "\n" <<<"$names")"
+  if [[ "$names" == "all" ]]; then
+    names="$(ry ls)"
+  else
+    names="$(tr , "\n" <<<"$names")"
+  fi
 
   for name in $names; do
     PATH="$(ry fullpath "$name")" "$@"
@@ -316,7 +321,7 @@ ry::usage() {
 
     ry exec <name>[,<name>[,...]] <command...>
                          Execute <command> in the context of each
-                         comma-separated ruby.
+                         comma-separated ruby (or all installed rubies with "all").
 
     ry binpath <name>    Print the bin directory for the given ruby
 


### PR DESCRIPTION
Hello,

Still enjoying ry here, and it's finally time to make this a pull request.

Basically, it selects all installed rubies when the first argument is not a ruby name.
If you don't like the behavior, I'd be fine with something like `ry exec all some_command`.

My Bash skills are very recent, so don't hesitate to heavily improve it.
