### PR TITLE
Patch for building MRI trunk and JRuby.

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -172,6 +172,11 @@ ry::build() {
 
   pushd "$builddir" > /dev/null
 
+  if [[ ! -x "./configure" ]] && [[ -f "./configure.in" ]] && [[ -x `which autoconf` ]]; then
+    log "running autoconf..."
+    autoconf
+  fi
+
   if [[ -x "./configure" ]]; then
     log "running configure script."
     "./configure --prefix=\"$install_prefix\" $config_args"
@@ -183,10 +188,26 @@ ry::build() {
   if [[ -f ./Makefile ]]; then
     log "Makefile found, building with PREFIX=\"$install_prefix\" make install"
     exists? make || abort "make is required to build this ruby."
-    PREFIX="$install_prefix" make install
+    PREFIX="$install_prefix" make && make install
   elif [[ -x ./installer ]]; then
-    log "./installer script found, running ./install --auto=\"$install_prefix\""
-    ./installer --auto="$install_prefix"
+    log "./installer script found, running ./install --auto=\"$install_prefix\" \"$config_args\""
+    ./installer --auto="$install_prefix" "$config_args"
+  elif [[ -f ./build.xml ]]; then
+    log "build.xml found, building JRuby with ant"
+    exists? ant || abort "ant is required to build this ruby."
+    ant jar
+
+    for binary in jirb jruby jgem ; do
+      log "linking "$binary" as ${binary#j}"
+      ln -fs "$binary" "bin/${binary#j}"
+    done
+
+    log "linking bin and lib directories"
+    ln -s "$builddir/bin" "$install_prefix/bin"
+    ln -s "$builddir/lib" "$install_prefix/lib"
+
+    log "Setting the JRUBY_HOME environment variable to $RY_LIB/current. It's recommended to add it to your shell profile."
+    export JRUBY_HOME=$RY_LIB/current
   elif [[ -f ./Rakefile ]]; then
     log "Rakefile found, building with PREFIX=\"$install_prefix\" rake install"
     exists? rake || abort "rake is required to build this ruby."


### PR DESCRIPTION
These are a few patches I've made in my fork and I thought
I would submit them back in case anyone else was interested.
Feel free to not accept these changes and/or hack them up.

Here are the commands I'm using to keep the latest versions:
ry install https://github.com/ruby/ruby/tarball/trunk trunk --enable-shared=yes
ry install https://github.com/rubinius/rubinius/tarball/master rbx-trunk --enable-version=1.8,1.9 --default-version=1.9
ry install https://github.com/jruby/jruby/tarball/master jruby-trunk

Note that Rubinius still requires some goofiness to get bundler
to work properly because it's stored in a subdirectory. 

I've added this to my shell profile. Any suggestions on a better way?

alias linkbundler='ln -s $RY_PREFIX/lib/ry/rubies/rbx-trunk/gems/1.9/bin/bundle $RY_PREFIX/lib/ry/current/bin/bundle'

This patch will run autoconf if it sees a configure.in file in the
source root but there's no configure script. This allows you to
point ry at the MRI git repo and it will run autoconf first and
then build it as usual. There's also a patch to be able to pass
args to the Rubinius installer script. Also in this patch is new
code path to build JRuby.
