### PR TITLE
Add a ry system command

### DIFF
--- a/bin/ry
+++ b/bin/ry
@@ -310,6 +310,14 @@ ry::remove() {
 ry::rm() { ry::remove "$@" ;}
 
 #
+# ry system
+# Fallback to the default system version
+#
+ry::system() {
+  rm -f "$RY_LIB/current"
+}
+
+#
 # Output usage information.
 #
 ry::usage() {
@@ -349,6 +357,8 @@ ry::usage() {
     ry fullpath [<name>] Print a modified version of \$PATH that exclusively
                          includes the given ruby's path.
                          If no name is given, uses the \`current\` symlink
+
+    ry system            Fallback to the default system version
 
 
   Options:

--- a/lib/ry.bash_completion
+++ b/lib/ry.bash_completion
@@ -19,6 +19,7 @@ __complete_ry() {
       echo remove
       echo rm
       echo usage
+      echo system
     )"
   else
     local command="${COMP_WORDS[1]}"

--- a/lib/ry.zsh_completion
+++ b/lib/ry.zsh_completion
@@ -11,7 +11,7 @@ if (( CURRENT > 2 )); then
   local subcmd="$words[1]"
 
   case $subcmd in
-    setup|use|remove|rm|exec|binpath|fullpath)
+    setup|use|remove|rm|exec|binpath|fullpath|system)
       rubies=($(_call_program rubies ry ls))
     ;;
     install)
@@ -41,6 +41,7 @@ else
     exec:'execute a command in the context of each comma-separated ruby'
     binpath:'print the bin directory for the given ruby'
     fullpath:'print a modified version of $PATH that exclusively includes the given ruby'
+    system:'fallback to the default system version'
   )
   rubies=($(_call_program rubies ry ls))
   _describe commands commands


### PR DESCRIPTION
Hello,

This pull request adds a ry system command to switch back to the version system since it's simpler than remove the symlink in the lib folder under `RY_PREFIX`.

By the way, I would love to thank you for ry. It's very minimal but KISS is the main principle in UNIX and it just works so a big thanks! :heart: 

Have a nice day.
