### PR TITLE
Ruby Installation directory set-able via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ export PATH="$RY_PREFIX/lib/ry/current/bin:$PATH"
 
 For ZSH completion, see [this](https://github.com/jayferd/ry/blob/master/lib/ry.zsh_completion).
 
+If you want to specify a different directory for installing rubies:
+
+```bash
+# rubies are installed into $RY_PREFIX/lib/ry/rubies
+# set RY_RUBIES for an alternate location
+export RY_RUBIES="$HOME/.rubies"
+```
+
 ## Usage
 
 Ry is a bit different from [other][rvm] [version][rbenv] [managers][nvm].  The major design goal of ry is to be explicit, unobtrusive, and easy to query.  In the vein of the [n][] package manager for node, there are no subshells, and the only thing it needs to add to your environment is a single entry to your `$PATH` (also tab completion if you like).  For example, here's how you create a new installation:

--- a/bin/ry
+++ b/bin/ry
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 # Library version
-VERSION="0.3.3"
+VERSION="0.4.0"
 
 [[ -z "$RY_PREFIX" ]] && RY_PREFIX="$HOME/.local"
-RY_LIB="${RY_PREFIX}/lib/ry"
+[[ -z "$RY_LIB" ]]    && RY_LIB="${RY_PREFIX}/lib/ry"
+[[ -z "$RY_RUBIES" ]] && RY_RUBIES="${RY_LIB}/rubies"
 
 #
 # Exit with the given <msg ...>
@@ -46,10 +47,10 @@ indir() {
 
 # setup
 
-[[ -d $RY_LIB/rubies ]] || mkdir -p $RY_LIB/rubies
+[[ -d $RY_RUBIES ]] || mkdir -p $RY_RUBIES
 
-if [[ ! -d $RY_LIB/rubies ]]; then
-  abort "Failed to create rubies directory ($RY_LIB/rubies), do you have permissions to do this?"
+if [[ ! -d $RY_RUBIES ]]; then
+  abort "Failed to create rubies directory ($RY_RUBIES), do you have permissions to do this?"
 fi
 
 # curl / wget support
@@ -89,7 +90,7 @@ sh
 # Display current ruby name
 # and others installed.
 ry::ls() {
-  for dir in $RY_LIB/rubies/*; do
+  for dir in $RY_RUBIES/*; do
     echo "${dir##*/}"
   done
 }
@@ -121,7 +122,7 @@ ry::install() {
   # use that instead :)
   [[ -z "$url" ]] && abort "no URL given.  usage: ry install <url> <name>"
   [[ -z "$name" ]] && name="$url"
-  local dir="$RY_LIB/rubies/$name"
+  local dir="$RY_RUBIES/$name"
   if exists? ruby-build \
   && ruby-build --definitions | grep -qx "$url"; then
     ruby-build "$url" "$dir"
@@ -130,7 +131,7 @@ ry::install() {
     local logpath="/tmp/ry.log"
 
     # create build directory
-    local builddir="$RY_LIB/rubies/$name/src"
+    local builddir="$RY_RUBIES/$name/src"
     mkdir -p $builddir
 
     echo -n "fetching <$url> ..."
@@ -167,7 +168,7 @@ ry::build() {
 
   assert_installed "$name"
 
-  local install_prefix="$RY_LIB/rubies/$name"
+  local install_prefix="$RY_RUBIES/$name"
   local builddir="$install_prefix/src"
 
   pushd "$builddir" > /dev/null
@@ -224,7 +225,7 @@ ry::build() {
 assert_installed() {
   if [[ -z "$1" ]]; then
     abort "ruby version missing"
-  elif [[ ! -d "$RY_LIB/rubies/$1" ]]; then
+  elif [[ ! -d "$RY_RUBIES/$1" ]]; then
     abort "no such ruby: $1"
   fi
 }
@@ -239,7 +240,7 @@ ry::use() {
   assert_installed "$name"
 
   rm -f "$RY_LIB/current"
-  indir "$RY_LIB" ln -s "rubies/$name" current
+  indir "$RY_RUBIES" ln -s "$name" current
   ry current
 }
 
@@ -252,7 +253,7 @@ ry::use() {
 ry::binpath() {
   local name="$1"; shift
   assert_installed "$name"
-  echo "$RY_LIB/rubies/$name/bin"
+  echo "$RY_RUBIES/$name/bin"
 }
 
 #
@@ -302,7 +303,7 @@ ry::remove() {
 
   while [[ $# != 0 ]]; do
     local name="$1"
-    rm -rf "$RY_LIB/rubies/$name"
+    rm -rf "$RY_RUBIES/$name"
     shift
   done
 }


### PR DESCRIPTION
I added the `RY_RUBIES` environment variable that defaults to `$RY_PREFIX/lib/ry/rubies`.

Note that I applied the version bump to `0.4.0` as I am assuming you are using semantic versioning, in which case this update should be a backward-compatible feature change.

I wasn't quite sure what magic is going on in `ry::fullpath`, so please advise if it I inadvertantly broke it.
